### PR TITLE
make sure short_title is callable before calling it

### DIFF
--- a/treeadmin/admin.py
+++ b/treeadmin/admin.py
@@ -210,7 +210,7 @@ class TreeAdmin(admin.ModelAdmin):
         r += '<span id="page_marker-%d" class="page_marker%s" style="width: %dpx;">&nbsp;</span>&nbsp;' % (
             item.id, editable_class, 14+item.level*18)
         #        r += '<span tabindex="0">'
-        if hasattr(item, 'short_title'):
+        if hasattr(item, 'short_title') and callable(item.short_title):
             r += item.short_title()
         else:
             r += unicode(item)


### PR DESCRIPTION
If the model has a `short_title`, the admin will try `short_title()` whether or not it's actually callable, the way the FeinCMS `short_title` is. So, we'd better check first.
