### PR TITLE
Remove adminmedia templatetag which is deprecated in Django 1.5

### DIFF
--- a/treeadmin/templates/admin/treeadmin/tree_editor.html
+++ b/treeadmin/templates/admin/treeadmin/tree_editor.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load adminmedia admin_list i18n %}
+{% load admin_list i18n %}
 
 {% block extrahead %}
 {{ block.super }}


### PR DESCRIPTION
Django 1.5 now raises an error when the `adminmedia` templatetag is included. The pull request simply removes it as it is not used anyway.

Shouldn't interfere with pull request #4.
